### PR TITLE
setup.py: fix url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,
-    url="https://github.com/DiamondLightSource/zocalo-python-dls",
+    url="https://github.com/DiamondLightSource/python-zocalo-dls",
     version="0.2.0",
     zip_safe=False,
 )


### PR DESCRIPTION
Noticed the incorrect url on [the PyPI page](https://pypi.org/project/zocalo-dls/): I assume that fixing it here will also fix it there when a new release is pushed? Or is manual intervention required?